### PR TITLE
Correct module check to not throw an error

### DIFF
--- a/packages/storybook-addon-designs/src/index.ts
+++ b/packages/storybook-addon-designs/src/index.ts
@@ -23,7 +23,7 @@ export const withDesign = makeDecorator({
  */
 export const config = (c: Config | Config[]) => c;
 
-if (module && module.hot && module.hot.decline) {
+if (typeof module !== 'undefined' && module.hot && module.hot.decline) {
   module.hot.decline();
 }
 


### PR DESCRIPTION
In esm mode, module does not exist and will throw an error if checked via `if(module)`