### PR TITLE
Fix README badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <br/>
   <br/>
 
-[![npm version](https://badge.fury.io/js/@storybook/addon-designs.svg)](https://badge.fury.io/js/@storybook/addon-designs)
+[![npm version](https://badge.fury.io/js/@storybook%2Faddon-designs.svg)](https://badge.fury.io/js/@storybook%2Faddon-designs)
 [![Monthly download](https://img.shields.io/npm/dm/@storybook/addon-designs.svg)](https://www.npmjs.com/package/@storybook/addon-designs)
-[![GitHub license](https://img.shields.io/github/license/pocka/@storybook/addon-designs.svg)](https://github.com/pocka/@storybook/addon-designs/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/storybookjs/addon-designs.svg)](https://github.com/storybookjs/addon-designs/blob/master/LICENSE)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 </div>


### PR DESCRIPTION
It seems some of the badge URLs went broken at time of 7.0 release.
Alt texts were shown for each broken badges.

With this patch, all badges would be displayed correctly.