### PR TITLE
Update repository URL to storybookjs/addon-designs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,4 @@
 6. Run `npm version <new-version> --include-workspace-root --force`. (`<new-version>` is the same one you specified at step 4)
 7. Push the generated commit and tag.
 8. Wait for CI publish the new version to npm.
-9. Create a new release on [GitHub](https://github.com/pocka/storybook-addon-designs/releases).
+9. Create a new release on [GitHub](https://github.com/storybookjs/addon-designs/releases).

--- a/packages/examples/stories/tests/issues/156.stories.tsx
+++ b/packages/examples/stories/tests/issues/156.stories.tsx
@@ -7,7 +7,7 @@ export default {
     docs: {
       page: () => (
         <div>
-          <a href="https://github.com/pocka/storybook-addon-designs/discussions/155">
+          <a href="https://github.com/storybookjs/addon-designs/discussions/155">
             Original discussion
           </a>
           <Figma url="https://www.figma.com/file/Klm6pxIZSaJFiOMX5FpTul9F/storybook-addon-designs-sample" />

--- a/packages/storybook-addon-designs/package.json
+++ b/packages/storybook-addon-designs/package.json
@@ -70,7 +70,7 @@
     "figma"
   ],
   "storybook": {
-    "icon": "https://raw.githubusercontent.com/pocka/storybook-addon-designs/master/packages/assets/logo.png",
+    "icon": "https://raw.githubusercontent.com/storybookjs/addon-designs/master/packages/assets/logo.png",
     "displayName": "Designs"
   },
   "publishConfig": {

--- a/packages/storybook-addon-designs/src/register/components/ErrorBoundary.tsx
+++ b/packages/storybook-addon-designs/src/register/components/ErrorBoundary.tsx
@@ -48,7 +48,7 @@ export class ErrorBoundary extends Component {
               See console log for more details. To clear the error state, please
               reload the page.{" "}
               <Link
-                href="https://github.com/pocka/storybook-addon-designs/issues/new?assignees=&labels=category%3A+bug&template=bug_report.yml"
+                href="https://github.com/storybookjs/addon-designs/issues/new?assignees=&labels=category%3A+bug&template=bug_report.yml"
                 target="_blank"
                 rel="noopener"
                 withArrow

--- a/packages/storybook-addon-designs/src/register/components/IFrame.tsx
+++ b/packages/storybook-addon-designs/src/register/components/IFrame.tsx
@@ -30,7 +30,7 @@ export const IFrame: FC<Props> = ({ config, defer = false }) => {
   // statement in the Fulscreen API spec).
   // This side-effect delays the loading of an iframe contents by one frame to
   // make sure the contents gets updated attributes.
-  // https://github.com/pocka/storybook-addon-designs/issues/77
+  // https://github.com/storybookjs/addon-designs/issues/77
   useEffect(() => {
     if (!defer) {
       return;

--- a/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
+++ b/packages/storybook-addon-designs/src/register/components/Wrapper.tsx
@@ -97,6 +97,9 @@ export const Wrapper: FC<Props> = ({ config }) => {
           };
       }
 
+      // FIXME: Link is temporarily set to source code due to "Available config types" section
+      //        had been removed from README. We need to add a list to README or docs site.
+      //        This is very much user-unfriendly, especially for whom not familier with TypeScript.
       return {
         ...meta,
         content: (
@@ -105,7 +108,7 @@ export const Wrapper: FC<Props> = ({ config }) => {
             <Fragment>
               Config type you set is not supported. Please choose one from{" "}
               <Link
-                href="https://github.com/pocka/storybook-addon-designs#available-types"
+                href="https://github.com/storybookjs/addon-designs/blob/master/packages/storybook-addon-designs/src/config.ts"
                 target="_blank"
                 rel="noopener"
                 withArrow


### PR DESCRIPTION
Some URLs still refer old repo (`pocka/storybook-addon-designs`).
This patch is basically `s/pocka\/storybook-addon-designs/storybookjs\/addon-designs/g` except one with `FIXME:` comment.