### PR TITLE
Don't use key anymore for rendering addon

### DIFF
--- a/packages/storybook-addon-designs/src/register/index.tsx
+++ b/packages/storybook-addon-designs/src/register/index.tsx
@@ -53,12 +53,13 @@ export default function register(renderTarget: "panel" | "tab") {
         match: ({ viewMode }) => viewMode === "design",
       });
     } else {
-      addons.addPanel(PanelName, {
+      addons.add(PanelName, {
+        type: types.PANEL,
         title,
         paramKey: ParameterName,
-        render({ active, key }) {
+        render({ active }) {
           return (
-            <AddonPanel key={key} active={!!active}>
+            <AddonPanel active={!!active}>
               <ErrorBoundary>
                 <Wrapper active={!!active} />
               </ErrorBoundary>


### PR DESCRIPTION
See https://github.com/storybookjs/storybook/pull/23792
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.0.2--canary.207.ad30797.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/addon-designs@7.0.2--canary.207.ad30797.0
  # or 
  yarn add @storybook/addon-designs@7.0.2--canary.207.ad30797.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
