### PR TITLE
Re-enable GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -1,0 +1,32 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build addon
+        run: npm run build
+      - name: Build examples
+        run: npm run build:example
+      - name: Deploy examples
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./packages/examples/storybook-static

--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - master
     tags-ignore:
-      - '*'
+      - "*"
 
 jobs:
-  deploy:
-    name: Deploy
+  build:
+    name: Build live examples
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,8 +25,22 @@ jobs:
         run: npm run build
       - name: Build examples
         run: npm run build:example
-      - name: Deploy examples
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/examples/storybook-static
+          path: ./packages/examples/storybook-static
+
+  deploy:
+    name: Deploy
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This PR re-enables a GitHub Actions workflow that builds example Storybook then deploys it to GitHub Pages. I have also changed the deploy action to the new official action from third party one (5500a94c3923c945fc891f2bd801b3c5da625d39).

Fix #187.