### PR TITLE
Ignore auto generated CHANGELOG from formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 storybook-static
 cjs
 esm
+
+# Auto generated file
+/packages/storybook-addon-designs/CHANGELOG.md


### PR DESCRIPTION
The file is auto generated thus should not be formatted.
This patch fixes ["Check code validity" workflow](https://github.com/storybookjs/addon-designs/actions/workflows/check-pushes.yml) failing.