### PR TITLE
feat(figma): migrate url to use embed kit v2

### DIFF
--- a/packages/storybook-addon-designs/src/manager/components/Figma.tsx
+++ b/packages/storybook-addon-designs/src/manager/components/Figma.tsx
@@ -45,21 +45,12 @@ export const Figma: FC<Props> = ({ config }) => {
 
 function createEmbedURL(encodedURL: string, embedHost: string) {
   const url = new URL(encodedURL);
-
-  if (url.hostname.startsWith("www")) {
-    url.hostname = "embed" + url.hostname.slice(3);
+  url.hostname = url.hostname.replace(/^www\./, "embed.");
+  url.searchParams.delete("embed_origin");
+  url.searchParams.set("embed-host", embedHost);
+  for (const [key, value] of url.searchParams) {
+    url.searchParams.delete(key);
+    url.searchParams.set(key.replace(/_/g, "-"), value);
   }
-
-  const params = new URLSearchParams(url.search);
-  params.set("embed-host", embedHost);
-  params.delete("embed_origin");
-
-  const newParams = new URLSearchParams();
-  for (const [key, value] of params) {
-    // migrating keys from figma's embed kit v1 to v2
-    newParams.append(key.replace(/_/g, "-"), value);
-  }
-
-  url.search = newParams.toString();
-  return url.toString();
+  return url.href;
 }

--- a/packages/storybook-addon-designs/src/manager/components/Figma.tsx
+++ b/packages/storybook-addon-designs/src/manager/components/Figma.tsx
@@ -30,7 +30,9 @@ export const Figma: FC<Props> = ({ config }) => {
     }
 
     const embedHost = config.embedHost || location.hostname;
-    const url = `https://www.figma.com/embed?embed_host=${embedHost}&url=${config.url}`;
+    const url = migrateEmbedURL(
+      `https://www.figma.com/embed?embed_host=${embedHost}&url=${config.url}`,
+    );
 
     return {
       url,
@@ -40,3 +42,45 @@ export const Figma: FC<Props> = ({ config }) => {
 
   return <IFrame defer config={iframeConfig} />;
 };
+
+function migrateEmbedURL(embedV1URL: string) {
+  // Parse the input URL
+  const oldURL = new URL(embedV1URL);
+  const params = new URLSearchParams(oldURL.search);
+
+  // Get the value of the 'url' parameter, decode it, and discard it
+  let embedURL = decodeURIComponent(params.get("url")!);
+  params.delete("url");
+
+  // Convert the subdomain of embedURL from 'www' to 'embed'
+  let embedURLObj = new URL(embedURL);
+  if (embedURLObj.hostname.startsWith("www")) {
+    embedURLObj.hostname = "embed" + embedURLObj.hostname.slice(3);
+  }
+
+  // Merge query parameters from embedURLObj into params
+  const embedURLParams = new URLSearchParams(embedURLObj.search);
+  for (const [key, value] of embedURLParams.entries()) {
+    params.append(key, value);
+  }
+
+  // Check for the 'embed_origin' parameter, warn if present, and discard it
+  if (params.has("embed_origin")) {
+    console.warn(
+      "embed_origin parameter is present:",
+      params.get("embed_origin"),
+    );
+    params.delete("embed_origin");
+  }
+
+  // Construct the new URL using the value of embedURL and remaining query parameters
+  const newParams = new URLSearchParams();
+  for (const [key, value] of params.entries()) {
+    const newKey = key.replace(/_/g, "-");
+    newParams.append(newKey, value);
+  }
+
+  // Combine the new URL and the new parameters
+  embedURLObj.search = newParams.toString();
+  return embedURLObj.toString();
+}


### PR DESCRIPTION
Hey!

Figma has recently released embed kit v2 which provides enhanced security features as well abit more control and flexibility over the embeds.

this PR migrates the url according to the guide in https://www.figma.com/developers/embed#migrate

Thanks