### PR TITLE
fix repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "version": "10.0.0",
   "private": true,
-  "repository": "git@github.com:storybookjs/addon-designs.git",
+  "repository": "git+https://github.com/storybookjs/addon-designs.git",
   "scripts": {
     "build": "pnpm -r run build",
     "build:example": "pnpm --filter examples run build-storybook && pnpm --filter examples run build-storybook:tab",

--- a/packages/storybook-addon-designs/package.json
+++ b/packages/storybook-addon-designs/package.json
@@ -11,7 +11,7 @@
     "preview"
   ],
   "homepage": "https://github.com/storybookjs/addon-designs",
-  "repository": "git@github.com:storybookjs/addon-designs.git",
+  "repository": "git+https://github.com/storybookjs/addon-designs.git",
   "license": "MIT",
   "author": "pocka <pockawoooh@gmail.com>",
   "type": "module",


### PR DESCRIPTION
## Summary

- update repository metadata from SSH shorthand to a GitHub HTTPS git URL in the root manifest
- update the published `@storybook/addon-designs` package manifest with the same HTTPS repository URL

## Validation

- parsed both package manifests and confirmed `repository` is `git+https://github.com/storybookjs/addon-designs.git`
- ran `npm pack --dry-run --ignore-scripts --json` from `packages/storybook-addon-designs`
- ran `git diff --check`
