### PR TITLE
Fix GitHub Pages deploy using deprecated artifact actions

### DIFF
--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build examples
         run: pnpm run build:example
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./packages/examples/storybook-static
 
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Bumps `actions/upload-pages-artifact` v2 → v3 and `actions/deploy-pages` v2 → v4 in `deploy-ghpages.yml`.
- These older majors depend on `actions/upload-artifact@v3`, which GitHub now automatically hard-fails, breaking the Pages deploy on every push to `master` (e.g. [run 28853739484](https://github.com/storybookjs/addon-designs/actions/runs/28853739484)).

## Context
This is a CI-only fix for the demo Storybook deploy to GitHub Pages; it does not affect the published `@storybook/addon-designs` package, so no changeset is included.

## Test plan
- [ ] Confirm the "Deploy to GitHub Pages" workflow succeeds on this PR / after merge to `master`.

Made with [Cursor](https://cursor.com)